### PR TITLE
Per-World support for CropControl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.programmerdan.minecraft</groupId>
 	<artifactId>cropcontrol</artifactId>
-	<version>1.0.2</version>
+	<version>1.1.0</version>
 	<packaging>jar</packaging>
 	<name>CropControl</name>
 	<url>https://github.com/DevotedMC/CropControl</url>
@@ -64,13 +64,13 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.10.2-R0.1-SNAPSHOT</version>
+			<version>1.12-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>vg.civcraft.mc.civmodcore</groupId>
 			<artifactId>CivModCore</artifactId>
-			<version>1.5.09</version>
+			<version>1.6.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -82,13 +82,13 @@
 		<dependency>
 			<groupId>vg.civcraft.mc.citadel</groupId>
 			<artifactId>Citadel</artifactId>
-			<version>3.7.02</version>
+			<version>3.9.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.aleksey</groupId>
 			<artifactId>castlegates</artifactId>
-			<version>1.0.12-SNAPSHOT</version>
+			<version>1.0.20-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/programmerdan/minecraft/cropcontrol/config/RootConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/cropcontrol/config/RootConfig.java
@@ -6,11 +6,14 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.bukkit.Bukkit;
+import org.bukkit.World;
 import org.bukkit.block.Biome;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.ItemStack;
 
 import com.programmerdan.minecraft.cropcontrol.CropControl;
+import com.programmerdan.minecraft.cropcontrol.config.RootConfig.ModifierConfig;
 import com.programmerdan.minecraft.cropcontrol.data.Crop;
 import com.programmerdan.minecraft.cropcontrol.data.Sapling;
 import com.programmerdan.minecraft.cropcontrol.data.TreeComponent;
@@ -77,7 +80,7 @@ public class RootConfig {
 		return config;
 	}
 	
-	public String predictDrops(BreakType breakType, UUID placer, UUID breaker, boolean harvestable, Biome biome, ItemStack tool) {
+	public String predictDrops(BreakType breakType, UUID placer, UUID breaker, boolean harvestable, Biome biome, ItemStack tool, World world) {
 		if (baseDrops == null || baseDrops.size() == 0) {
 			return "No drops configured for " + index;
 		}
@@ -104,6 +107,14 @@ public class RootConfig {
 			
 			if (dropMod.biomes.containsKey(biome)) { // biome
 				ModifierConfig modifier = dropMod.biomes.get(biome);
+				localChance *= modifier.chanceMod;
+				localMin += modifier.stackAdjust;
+				localMax += modifier.stackExpand;
+			}
+			
+			//per world support
+			if (dropMod.worlds.containsKey(world)) { // world
+				ModifierConfig modifier = dropMod.worlds.get(world.getName());
 				localChance *= modifier.chanceMod;
 				localMin += modifier.stackAdjust;
 				localMax += modifier.stackExpand;
@@ -153,7 +164,7 @@ public class RootConfig {
 		return message.toString();
 	}
 	
-	public List<ItemStack> realizeDrops(BreakType breakType, UUID placer, UUID breaker, boolean harvestable, Biome biome, ItemStack tool) {
+	public List<ItemStack> realizeDrops(BreakType breakType, UUID placer, UUID breaker, boolean harvestable, Biome biome, ItemStack tool, World world) {
 		LinkedList<ItemStack> outcome = new LinkedList<ItemStack>();
 		if (baseDrops == null || baseDrops.size() == 0) {
 			return outcome;
@@ -180,6 +191,14 @@ public class RootConfig {
 			
 			if (dropMod.biomes.containsKey(biome)) { // biome
 				ModifierConfig modifier = dropMod.biomes.get(biome);
+				localChance *= modifier.chanceMod;
+				localMin += modifier.stackAdjust;
+				localMax += modifier.stackExpand;
+			}
+			
+			//per world support
+			if (dropMod.worlds.containsKey(world)) { // world
+				ModifierConfig modifier = dropMod.worlds.get(world.getName());
 				localChance *= modifier.chanceMod;
 				localMin += modifier.stackAdjust;
 				localMax += modifier.stackExpand;
@@ -235,6 +254,10 @@ public class RootConfig {
 		
 		Map<Biome, ModifierConfig> biomes = new ConcurrentHashMap<Biome, ModifierConfig>();
 		
+		//per-world support
+		Map<String, ModifierConfig> worlds = new ConcurrentHashMap<String, ModifierConfig>();
+				
+				
 		ModifierConfig base = null;
 		
 		boolean requireHarvestable = true;
@@ -268,6 +291,30 @@ public class RootConfig {
 					}
 				}
 			} // else no unique settings per biome.
+			
+			ConfigurationSection worldConfigs = config.getConfigurationSection("biomes");
+			// unwraps worlds and divines modifier configs for each one listed.
+			if (worldConfigs != null) {
+				for (String worldName : worldConfigs.getKeys(false)) {
+					try {
+						//See if the world is included in the server
+						World match = Bukkit.getServer().getWorld(worldName);
+						if(match != null){
+							worlds.put(match.getName(), new ModifierConfig(worldConfigs.getConfigurationSection(worldName)));
+						}
+						/*	Biome match = Biome.valueOf(biome);
+						if (match != null) {
+							//TODO change from biomes list to worlds list.
+							biomes.put(match, new ModifierConfig(biomeConfigs.getConfigurationSection(biome)));
+						} else {
+							CropControl.getPlugin().warning("Unrecognized biome {0} in config at {1}", biome, config.getCurrentPath());
+						}*/
+					} catch (Exception e) {
+						CropControl.getPlugin().warning("Invalid world {0} in config at {1}", worldName, config.getCurrentPath());
+					}
+				}
+			} // else no unique settings per world.
+			
 			
 			ConfigurationSection breakConfigs = config.getConfigurationSection("breaktypes");
 			// unwraps break types and divines modifier configs for each one listed.

--- a/src/main/java/com/programmerdan/minecraft/cropcontrol/config/RootConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/cropcontrol/config/RootConfig.java
@@ -304,13 +304,6 @@ public class RootConfig {
 						if(match != null){
 							worlds.put(match.getName(), new ModifierConfig(worldConfigs.getConfigurationSection(worldName)));
 						}
-						/*	Biome match = Biome.valueOf(biome);
-						if (match != null) {
-							//TODO change from biomes list to worlds list.
-							biomes.put(match, new ModifierConfig(biomeConfigs.getConfigurationSection(biome)));
-						} else {
-							CropControl.getPlugin().warning("Unrecognized biome {0} in config at {1}", biome, config.getCurrentPath());
-						}*/
 					} catch (Exception e) {
 						CropControl.getPlugin().warning("Invalid world {0} in config at {1}", worldName, config.getCurrentPath());
 					}

--- a/src/main/java/com/programmerdan/minecraft/cropcontrol/config/RootConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/cropcontrol/config/RootConfig.java
@@ -113,11 +113,12 @@ public class RootConfig {
 			}
 			
 			//per world support
-			if (dropMod.worlds.containsKey(world)) { // world
+			if (dropMod.worlds.containsKey(world.getName())) { // world
 				ModifierConfig modifier = dropMod.worlds.get(world.getName());
 				localChance *= modifier.chanceMod;
 				localMin += modifier.stackAdjust;
 				localMax += modifier.stackExpand;
+				
 			}
 			
 			if (dropMod.breaks.containsKey(breakType)) { // break
@@ -197,11 +198,12 @@ public class RootConfig {
 			}
 			
 			//per world support
-			if (dropMod.worlds.containsKey(world)) { // world
+			if (dropMod.worlds.containsKey(world.getName())) { // world
 				ModifierConfig modifier = dropMod.worlds.get(world.getName());
 				localChance *= modifier.chanceMod;
 				localMin += modifier.stackAdjust;
 				localMax += modifier.stackExpand;
+
 			}
 			
 			if (dropMod.breaks.containsKey(breakType)) { // break

--- a/src/main/java/com/programmerdan/minecraft/cropcontrol/config/RootConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/cropcontrol/config/RootConfig.java
@@ -292,7 +292,7 @@ public class RootConfig {
 				}
 			} // else no unique settings per biome.
 			
-			ConfigurationSection worldConfigs = config.getConfigurationSection("biomes");
+			ConfigurationSection worldConfigs = config.getConfigurationSection("worlds");
 			// unwraps worlds and divines modifier configs for each one listed.
 			if (worldConfigs != null) {
 				for (String worldName : worldConfigs.getKeys(false)) {

--- a/src/main/java/com/programmerdan/minecraft/cropcontrol/handler/CropControlEventHandler.java
+++ b/src/main/java/com/programmerdan/minecraft/cropcontrol/handler/CropControlEventHandler.java
@@ -367,7 +367,7 @@ public class CropControlEventHandler implements Listener {
 						.append("\nTimeStamp: " + crop.getTimeStamp()).color(ChatColor.RED)
 						.append("\nHarvestable: " + crop.getHarvestable()).color(ChatColor.RED)
 						.append("\nNatural Drops: " + 
-								RootConfig.from(crop).predictDrops(BreakType.NATURAL, crop.getPlacer(), null, crop.getHarvestable(), block.getBiome(), null));
+								RootConfig.from(crop).predictDrops(BreakType.NATURAL, crop.getPlacer(), null, crop.getHarvestable(), block.getBiome(), null, block.getWorld()));
 
 				BaseComponent[] hoverMessage = hoverBuilder.create();
 
@@ -396,7 +396,7 @@ public class CropControlEventHandler implements Listener {
 						.append("\nTimeStamp: " + sapling.getTimeStamp()).color(ChatColor.RED)
 						.append("\nHarvestable: " + sapling.getHarvestable()).color(ChatColor.RED)
 						.append("\nNatural Drops: " + 
-								RootConfig.from(sapling).predictDrops(BreakType.NATURAL, sapling.getPlacer(), null, sapling.getHarvestable(), block.getBiome(), null));
+								RootConfig.from(sapling).predictDrops(BreakType.NATURAL, sapling.getPlacer(), null, sapling.getHarvestable(), block.getBiome(), null, block.getWorld()));
 
 				BaseComponent[] hoverMessage = hoverBuilder.create();
 
@@ -453,7 +453,7 @@ public class CropControlEventHandler implements Listener {
 								.append("\nPlacer: " + treeComponent.getPlacer())
 								.append("\nHarvestable: " + treeComponent.isHarvestable())
 								.append("\nNatural Drops: " + 
-										RootConfig.from(treeComponent).predictDrops(BreakType.NATURAL, treeComponent.getPlacer(), null, treeComponent.isHarvestable(), block.getBiome(), null));
+										RootConfig.from(treeComponent).predictDrops(BreakType.NATURAL, treeComponent.getPlacer(), null, treeComponent.isHarvestable(), block.getBiome(), null, block.getWorld()));
 
 
 				BaseComponent[] hoverMessage = hoverBuilder.create();
@@ -1598,6 +1598,7 @@ public class CropControlEventHandler implements Listener {
 	private void drop(Block block, Locatable dropable, UUID player, BreakType breakType) {
 		Location bLoc = block.getLocation();
 		Biome biome = block.getBiome();
+		World world = block.getWorld();
 		UUID placePlayer = null; 
 		boolean byPlayer = player != null;
 		boolean harvestable = false;
@@ -1628,7 +1629,7 @@ public class CropControlEventHandler implements Listener {
 			}
 		}
 		
-		List<ItemStack> items = config.realizeDrops(breakType, placePlayer, player, harvestable, biome, toolUsed);
+		List<ItemStack> items = config.realizeDrops(breakType, placePlayer, player, harvestable, biome, toolUsed, world);
 		if (items != null) {
 			CropControlDropEvent event = new CropControlDropEvent(bLoc, breakType, dropable, player, items);
 			Bukkit.getPluginManager().callEvent(event);

--- a/src/main/java/com/programmerdan/minecraft/cropcontrol/handler/CropControlEventHandler.java
+++ b/src/main/java/com/programmerdan/minecraft/cropcontrol/handler/CropControlEventHandler.java
@@ -14,6 +14,7 @@ import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.TreeType;
+import org.bukkit.World;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -64,11 +64,11 @@ crops:
       world:
        adjust: -1
        chance: 1.5
-       extend: 2
+       expand: 2
       world_nether:
        adjust: 1
        chance: 0.5
-       extend: -1
+       expand: -1
      # An enhancement of PLAYER break type, allows unique override based on if same player or diff player breaks it vs. planted it 
      player:
       same:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -60,6 +60,15 @@ crops:
        adjust: 1
        chance: 0.5
        extend: -1
+     worlds:
+      world:
+       adjust: -1
+       chance: 1.5
+       extend: 2
+      world_nether:
+       adjust: 1
+       chance: 0.5
+       extend: -1
      # An enhancement of PLAYER break type, allows unique override based on if same player or diff player breaks it vs. planted it 
      player:
       same:


### PR DESCRIPTION
Adds per world controls for CropControl in much the same way as you are currently able with biomes. It searches by world name, so it should have multiworld support.